### PR TITLE
Add `Clone` derive to `SurfaceNetsBuffer`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl SignedDistance for f32 {
 }
 
 /// The output buffers used by [`surface_nets`]. These buffers can be reused to avoid reallocating memory.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SurfaceNetsBuffer {
     /// The triangle mesh positions.
     ///


### PR DESCRIPTION
`SurfaceNetsBuffer` doesn't implement `Clone` despite being entirely made up of `Clone` types. Deriving `Clone` for `SurfaceNetsBuffer` would make it easier to use in some situations, such as in rayon's `ParallelIterator::fold_with` method.