### PR TITLE
Fixed bug where last planes on each axis of SDF were not being used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fast-surface-nets"
 description = "A fast, chunk-friendly implementation of Naive Surface Nets on regular grids."
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bonsairobo/fast-surface-nets-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ keywords = ["graphics", "isosurface", "mesh", "voxel"]
 [dependencies]
 glam = "0.23" # For SIMD Vec3A
 ndshape = "0.3"
+
+[features]
+eval-max-plane = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,8 @@ pub fn surface_nets<T, S>(
     // SAFETY
     // Make sure the slice matches the shape before we start using get_unchecked.
     assert!(shape.linearize(min) <= shape.linearize(max));
-    assert!((shape.linearize(max) as usize) < sdf.len());
+    assert!(max[0] > 0 && max[1] > 0 && max[2] > 0);
+    assert!((shape.linearize([max[0] - 1, max[1] - 1, max[2] - 1]) as usize) < sdf.len());
 
     output.reset(sdf.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,6 @@ pub fn surface_nets<T, S>(
     // SAFETY
     // Make sure the slice matches the shape before we start using get_unchecked.
     assert!(shape.linearize(min) <= shape.linearize(max));
-    assert!(max[0] > 0 && max[1] > 0 && max[2] > 0);
     assert!((shape.linearize([max[0] - 1, max[1] - 1, max[2] - 1]) as usize) < sdf.len());
 
     output.reset(sdf.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub fn surface_nets<T, S>(
     // SAFETY
     // Make sure the slice matches the shape before we start using get_unchecked.
     assert!(shape.linearize(min) <= shape.linearize(max));
-    assert!((shape.linearize([max[0] - 1, max[1] - 1, max[2] - 1]) as usize) < sdf.len());
+    assert!((shape.linearize(max) as usize) < sdf.len());
 
     output.reset(sdf.len());
 
@@ -301,9 +301,10 @@ fn make_all_quads<T, S>(
         .zip(output.surface_strides.iter())
     {
         let p_stride = p_stride as usize;
+        let eval_max_plane = cfg!(feature = "eval-max-plane");
 
         // Do edges parallel with the X axis
-        if y != miny && z != minz && x != maxx - 1 {
+        if y != miny && z != minz && (eval_max_plane || x != maxx - 1) {
             maybe_make_quad(
                 sdf,
                 &output.stride_to_index,
@@ -316,7 +317,7 @@ fn make_all_quads<T, S>(
             );
         }
         // Do edges parallel with the Y axis
-        if x != minx && z != minz && y != maxy - 1 {
+        if x != minx && z != minz && (eval_max_plane || y != maxy - 1) {
             maybe_make_quad(
                 sdf,
                 &output.stride_to_index,
@@ -329,7 +330,7 @@ fn make_all_quads<T, S>(
             );
         }
         // Do edges parallel with the Z axis
-        if x != minx && y != miny && z != maxz - 1 {
+        if x != minx && y != miny && (eval_max_plane || z != maxz - 1) {
             maybe_make_quad(
                 sdf,
                 &output.stride_to_index,


### PR DESCRIPTION
Say we had an SDF with shape `(10, 10, 10)`. It would have 1000 elements. Previously, `surface_nets` would `assert!((shape.linearize(max) as usize) < sdf.len())`. Calling `surface_nets` with `max = (10, 10, 10)` would result in `shape.linearize((10, 10, 10)) = 10 + (10 * 10) + (10 * 10 * 10) = 1110`. You must call it with `max = (9, 9, 9)` in order to get `shape.linearize((9, 9, 9)) = 9 + (9 * 10) + (9 * 10 * 10) = 999`. The problem with this is that in `estimate_surface`, the indices are `[min, max)` and do not include the max values. So, we end up excluding the max values twice and lose the final planes on each axis of the SDF.

I propose modifying the assert to subtract 1 from each value `max` in order to match the size of the loop in `estimate_surface`. I also added an assert to ensure we don't have negative indices for max and bumped the version number. Maybe it should be 0.3 instead of 0.2.1 as it will likely cause changes in results.

I do have one question about the assert on line 138. Surely `shape.linearize(min)` MUST be less than `shape.linearize(max)` to produce any result. If so, we could modify it to a `<` and assert `shape.linearize(min) >= 0`.