### PR TITLE
ci: Add minimal CI using GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    name: cargo fmt
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
+  test:
+    runs-on: ubuntu-latest
+    name: cargo clippy + test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test
+
+  check-benchmark:
+    runs-on: ubuntu-latest
+    name: cargo check bench
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --manifest-path=bench/Cargo.toml -- -D warnings


### PR DESCRIPTION
This adds some minimal CI that:

* Checks code formatting.
* Runs tests on the main crate.
* Runs clippy on the main crate.
* Runs clippy to make sure the benchmark compiles.

It does not do anything with the examples crate yet as that doesn't currently compile.