### PR TITLE
Fix for 'centroid_of_edge_intersections' function not using 'is_negative' from 'SignedDistance' trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ fn centroid_of_edge_intersections<T>(dists: &[f32; 8]) -> Vec3A
         let d1 = dists[corner1 as usize];
         let d2 = dists[corner2 as usize];
         let v1: T = d1.into();
-        let v2: T = d1.into();
+        let v2: T = d2.into();
         if v1.is_negative() != v2.is_negative() {
             count += 1;
             sum += estimate_surface_edge_intersection(corner1, corner2, d1, d2);


### PR DESCRIPTION
Fix for 'SignedDistance' trait where 'is_negative' function was not used in the 'centroid_of_edge_intersections' function resulting in wrong or infinite vectors/normals.

I dont know if this is the correct way and in line with how you want it to be developed. But it works!