### PR TITLE
fix #23

### DIFF
--- a/examples-crate/Cargo.toml
+++ b/examples-crate/Cargo.toml
@@ -9,7 +9,7 @@ obj-exporter = "0.2"
 rayon = "1.8"
 rand = "0.8"
 
-ilattice = {version = "0.4.0", default-features = false, features = ["glam"]}
+ilattice = {version = "0.4.0", default-features = false, features = ["glam", "rayon"]}
 
 [dependencies.fast-surface-nets]
 path = ".."

--- a/examples-crate/Cargo.toml
+++ b/examples-crate/Cargo.toml
@@ -9,7 +9,7 @@ obj-exporter = "0.2"
 rayon = "1.8"
 rand = "0.8"
 
-ilattice = { git = "https://github.com/bonsairobo/ilattice-rs", branch = "main", default-features = false, features = ["glam"]}
+ilattice = {version = "0.4.0", default-features = false, features = ["glam"]}
 
 [dependencies.fast-surface-nets]
 path = ".."

--- a/examples-crate/rayon-chunks/main.rs
+++ b/examples-crate/rayon-chunks/main.rs
@@ -245,8 +245,7 @@ fn generate_chunks() -> Vec<(Vec3A, SurfaceNetsBuffer)> {
 
     let unpadded_chunk_shape = IVec3::from([UNPADDED_CHUNK_SIDE as i32; 3]);
     let chunks: Vec<_> = chunks_extent
-        .iter3()
-        .par_bridge()
+        .par_iter3()
         .filter_map(|p| {
             let chunk_min = p * unpadded_chunk_shape;
 

--- a/examples-crate/rayon-chunks/main.rs
+++ b/examples-crate/rayon-chunks/main.rs
@@ -1,6 +1,6 @@
-use fast_surface_nets::glam::Vec3A;
 use fast_surface_nets::ndshape::{ConstShape, ConstShape3u32};
 use fast_surface_nets::{surface_nets, SurfaceNetsBuffer};
+use ilattice::glam::{IVec3,Vec3A};
 use ilattice::prelude::*;
 use rand::{Rng, rngs::StdRng, SeedableRng};
 use rayon::prelude::*;


### PR DESCRIPTION
Use the released version of ilattice (0.4.0).
Force the same glam version of IVec3 and Vec3A.
