### PR TITLE
Added feature delegation of glam/core-simd and glam/fast-math

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ ndshape = "0.3"
 
 [features]
 eval-max-plane = []
+glam-core-simd  = ["glam/core-simd"]
+glam-fast-math = ["glam/fast-math"]


### PR DESCRIPTION
This way we can enable these glam features on the glam version fsn is using, regardless of version.

` cargo tree -f "{p} {f}"` tested with the feature delegation flags:

```
├── fast-surface-nets v0.2.1 (fast-surface-nets-rs_eadf) glam-core-simd,glam-fast-math
│   ├── glam v0.29.3 core-simd,default,fast-math,std
```

and without:
 ```
 ├── fast-surface-nets v0.2.1 (fast-surface-nets-rs_eadf) 
│   ├── glam v0.29.3 default,std
 ```